### PR TITLE
System.ServiceModel.ChannelFactory - fix memory leak of OpenedChannel…

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel/ChannelFactory_1.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel/ChannelFactory_1.cs
@@ -156,11 +156,12 @@ namespace System.ServiceModel
 #else
 			var proxy = (IClientChannel) new ClientRealProxy (typeof (TChannel), new ClientRuntimeChannel (Endpoint, this, address ?? Endpoint.Address, via), false).GetTransparentProxy ();
 #endif
+			var holder = new OpenedChannelHolder (proxy);	
 			proxy.Opened += delegate {
-				OpenedChannels.Add (proxy);
+				OpenedChannels [holder] = byte.MinValue;
 			};
 			proxy.Closing += delegate {
-				OpenedChannels.Remove (proxy);
+				OpenedChannels.TryRemove (holder, out _);
 			};
 
 			return (TChannel) proxy;


### PR DESCRIPTION
…s not being removed.  The remoting proxy object's Equals method was returning false when trying to remove from the list



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
