### PR TITLE
System.ServiceModel - Workaround for Task<T> based async operations. …

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/OperationDescription.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/OperationDescription.cs
@@ -39,7 +39,7 @@ namespace System.ServiceModel.Description
 	[DebuggerDisplay ("Name={name}, IsInitiating={isInitiating}, IsTerminating={isTerminating}")]
 	public class OperationDescription
 	{
-		MethodInfo begin_method, end_method, sync_method;
+		MethodInfo begin_method, end_method, sync_method, task_method;
 		FaultDescriptionCollection faults
 			= new FaultDescriptionCollection ();
 		ContractDescription contract;
@@ -81,8 +81,8 @@ namespace System.ServiceModel.Description
 
 		[MonoTODO]
 		public MethodInfo TaskMethod {
-			get { throw new NotImplementedException (); }
-			set { throw new NotImplementedException (); }
+			get { return task_method; }
+			set { task_method = value; }
 		}
 
 		public ContractDescription DeclaringContract {


### PR DESCRIPTION
System.ServiceModel - Workaround for Task<T> based async WCF operations.  The operation will block and return a completed Task<T>.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
