### PR TITLE
System.ServiceModel - set XmlWriter/Reader CheckCharacters to false

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/BodyWriter.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/BodyWriter.cs
@@ -63,6 +63,7 @@ namespace System.ServiceModel.Channels
 			var s = new XmlWriterSettings ();
 			s.OmitXmlDeclaration = true;
 			s.ConformanceLevel = ConformanceLevel.Auto;
+			s.CheckCharacters = false;
 			StringWriter sw = new StringWriter ();
 			using (XmlDictionaryWriter w = XmlDictionaryWriter.CreateDictionaryWriter (XmlWriter.Create (sw, s)))
 				WriteBodyContents (w);

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/Message.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/Message.cs
@@ -132,6 +132,7 @@ namespace System.ServiceModel.Channels
 			XmlWriterSettings settings = new XmlWriterSettings ();
 			settings.Indent = true;
 			settings.OmitXmlDeclaration = true;
+			settings.CheckCharacters = false;
 
 			using (XmlWriter w = XmlWriter.Create (sw, settings)) {
 				OnBodyToString (XmlDictionaryWriter.CreateDictionaryWriter (w));
@@ -235,6 +236,7 @@ namespace System.ServiceModel.Channels
 			var s = new XmlWriterSettings ();
 			s.OmitXmlDeclaration = true;
 			s.ConformanceLevel = ConformanceLevel.Auto;
+			s.CheckCharacters = false;
 			StringWriter sw = new StringWriter ();
 			using (XmlDictionaryWriter w = XmlDictionaryWriter.CreateDictionaryWriter (XmlWriter.Create (sw, s)))
 				WriteBodyContents (w);
@@ -253,6 +255,7 @@ namespace System.ServiceModel.Channels
 		{
 			var ws = new XmlWriterSettings ();
 			ws.ConformanceLevel = ConformanceLevel.Auto;
+			ws.CheckCharacters = false;
 			StringWriter sw = new StringWriter ();
 			using (XmlDictionaryWriter body = XmlDictionaryWriter.CreateDictionaryWriter (XmlWriter.Create (sw, ws))) {
 				WriteBodyContents (body);
@@ -266,6 +269,7 @@ namespace System.ServiceModel.Channels
 			
 			var rs = new XmlReaderSettings ();
 			rs.ConformanceLevel = ConformanceLevel.Auto;
+			rs.CheckCharacters = false;
 			
 			return XmlDictionaryReader.CreateDictionaryReader (XmlReader.Create (new StringReader (sw.ToString ()), rs, pc));
 		}

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/XmlReaderBodyWriter.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/XmlReaderBodyWriter.cs
@@ -46,7 +46,8 @@ namespace System.ServiceModel.Channels
 			var settings = new XmlReaderSettings () {
 				// FIXME: enable this line (once MaxCharactersInDocument is implemented)
 				// MaxCharactersInDocument = maxBufferSize,
-				ConformanceLevel = ConformanceLevel.Fragment
+				ConformanceLevel = ConformanceLevel.Fragment,
+				CheckCharacters = false
 				};
 			reader = XmlDictionaryReader.CreateDictionaryReader (XmlReader.Create (new StringReader (xml), settings, ctx));
 			reader.MoveToContent ();
@@ -71,7 +72,7 @@ namespace System.ServiceModel.Channels
 				if (consumed)
 					throw new InvalidOperationException ("Body xml reader is already consumed");
 				var sw = new StringWriter ();
-				var xw = XmlDictionaryWriter.CreateDictionaryWriter (XmlWriter.Create (sw));
+				var xw = XmlDictionaryWriter.CreateDictionaryWriter (XmlWriter.Create (sw, new XmlWriterSettings () { CheckCharacters = false }));
 				xw.WriteStartElement (reader.Prefix, reader.LocalName, reader.NamespaceURI);
 				for (int i = 0; i < reader.AttributeCount; i++) {
 					reader.MoveToAttribute (i);
@@ -119,7 +120,7 @@ namespace System.ServiceModel.Channels
 				throw new InvalidOperationException ("Body xml reader is already consumed");
 			if (reader == null && String.IsNullOrEmpty (xml_bak))
 				return;
-			XmlReader r = xml_bak != null ? XmlReader.Create (new StringReader (xml_bak), null, parser_context) : reader;
+			XmlReader r = xml_bak != null ? XmlReader.Create (new StringReader (xml_bak), new XmlReaderSettings () { CheckCharacters = false }, parser_context) : reader;
 			r.MoveToContent ();
 			writer.WriteNode (r, false);
 			if (xml_bak == null)


### PR DESCRIPTION
System.ServiceModel - set XmlWriter/Reader CheckCharacters setting to false in Message.CreateBufferedCopy() impl to keep consistent as in windows



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
